### PR TITLE
Potential fix for download form issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -87,7 +87,6 @@ waitForConfig.promise.then(function() {
       res.setHeader('Content-type', 'application/octet-stream');
       res.setHeader('Content-disposition', 'attachment; filename=custom_signup.zip');
       res.send(archive.toBuffer());
-      res.end();
     });
   });
 


### PR DESCRIPTION
Removing res.end() call that may be causing issues in production. Should be unnecessary since res.send() invokes res.end().

See https://github.com/Adapp/Publisher_Interface/issues/1235

Was able to repro the issue on my dev instance, and this change appeared to fix it.
