### PR TITLE
Update zip library and modify file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "express": "~3.0.0",
     "jade": "~0.29.0",
-    "node-native-zip": "~1.1.0",
+    "node-zip": "~1.1.0",
     "handlebars": "*",
     "q": "~0.8.12",
     "express-winston": "~0.2.0",

--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ waitForConfig.promise.then(function() {
   });
 
   app.post('/compile', function(req, res) {
-    zipper(req.body, function(archive) {
+    zipper(req.body, __dirname, function(archive) {
       res.setHeader('Content-type', 'application/octet-stream');
       res.setHeader('Content-disposition', 'attachment; filename=custom_signup.zip');
       res.send(archive.toBuffer());

--- a/server.js
+++ b/server.js
@@ -86,7 +86,7 @@ waitForConfig.promise.then(function() {
     zipper(req.body, __dirname, function(archive) {
       res.setHeader('Content-type', 'application/octet-stream');
       res.setHeader('Content-disposition', 'attachment; filename=custom_signup.zip');
-      res.send(archive.toBuffer());
+      res.send(archive);
     });
   });
 

--- a/zipBuilder.js
+++ b/zipBuilder.js
@@ -41,8 +41,6 @@ module.exports = function(context, basePath, cb) {
   var archive = new zip(),
       folderName = 'custom_signup';
 
-  archive.folder(folderName);
-
   //Compile the html then the javascript.
   compileAndArchive(basePath + '/package/index.html', folderName + '/index.html', archive, context).then(function() {
     return compileAndArchive(basePath + '/package/signup.js', folderName + '/js/signup.js', archive, context);
@@ -54,6 +52,8 @@ module.exports = function(context, basePath, cb) {
     ]).then(function() {
       var output = archive.generate({type:'nodebuffer', compression: 'STORE'});
       cb(output);
+    }, function(err) {
+      console.log(err);
     });
   });
 };

--- a/zipBuilder.js
+++ b/zipBuilder.js
@@ -27,9 +27,9 @@ function compileAndArchive(localPath, zipPath, archive, context) {
 module.exports = function(context, basePath, cb) {
   var archive = new zip(),
       uncompiled = [
-          {'name': 'css/foundation.min.css', 'path': basePath + '/package/foundation.min.css'},
-          {'name': 'js/modernizr.foundation.min.js', 'path': basePath + '/package/modernizr.foundation.js'},
-          {'name': 'js/foundation.min.js', 'path': basePath + '/package/foundation.min.js'}
+          {'name': 'css/foundation.min.css', 'path': './package/foundation.min.css'},
+          {'name': 'js/modernizr.foundation.min.js', 'path': './package/modernizr.foundation.js'},
+          {'name': 'js/foundation.min.js', 'path': './package/foundation.min.js'}
       ];
 
   //Compile the html then the javascript.

--- a/zipBuilder.js
+++ b/zipBuilder.js
@@ -12,25 +12,29 @@ hb.registerHelper('escapeQuotes', function(entity) {
 function compileAndArchive(localPath, zipPath, archive, context) {
   var dfd = Q.defer();
   fs.readFile(localPath, 'utf8', function(err, data) {
-    if(err) { dfd.reject(err); return; }
+    if(err) {
+      console.log(err);
+      dfd.reject(err);
+      return;
+    }
     var template = hb.compile(data);
     archive.add(zipPath, new Buffer(template(context), 'utf8'));
     dfd.resolve();
   });
   return dfd.promise;
-};
+}
 
-module.exports = function(context, cb) {
+module.exports = function(context, basePath, cb) {
   var archive = new zip(),
       uncompiled = [
-          {'name': 'css/foundation.min.css', 'path': './package/foundation.min.css'},
-          {'name': 'js/modernizr.foundation.min.js', 'path': './package/modernizr.foundation.js'},
-          {'name': 'js/foundation.min.js', 'path': './package/foundation.min.js'}
+          {'name': 'css/foundation.min.css', 'path': basePath + '/package/foundation.min.css'},
+          {'name': 'js/modernizr.foundation.min.js', 'path': basePath + '/package/modernizr.foundation.js'},
+          {'name': 'js/foundation.min.js', 'path': basePath + '/package/foundation.min.js'}
       ];
 
   //Compile the html then the javascript.
-  compileAndArchive('./package/index.html', 'index.html', archive, context).then(function() {
-    return compileAndArchive('./package/signup.js', 'js/signup.js', archive, context);
+  compileAndArchive(basePath + '/package/index.html', 'index.html', archive, context).then(function() {
+    return compileAndArchive(basePath + '/package/signup.js', 'js/signup.js', archive, context);
   }).then(function() {
     archive.addFiles(uncompiled, function(err) {
       if (err) {console.log(err);}

--- a/zipBuilder.js
+++ b/zipBuilder.js
@@ -12,7 +12,7 @@ hb.registerHelper('escapeQuotes', function(entity) {
 function compileAndArchive(localPath, zipPath, archive, context) {
   var dfd = Q.defer();
   fs.readFile(localPath, 'utf8', function(err, data) {
-    if(err) {
+    if (err) {
       dfd.reject(err);
       return;
     }

--- a/zipBuilder.js
+++ b/zipBuilder.js
@@ -13,7 +13,6 @@ function compileAndArchive(localPath, zipPath, archive, context) {
   var dfd = Q.defer();
   fs.readFile(localPath, 'utf8', function(err, data) {
     if(err) {
-      console.log(err);
       dfd.reject(err);
       return;
     }
@@ -28,11 +27,11 @@ function addUncompiled(localPath, zipPath, archive) {
   var dfd = Q.defer();
   fs.readFile(localPath, function(err, data) {
     if (err) {
-      console.log(err);
-    } else {
-      archive.file(zipPath, data);
-      dfd.resolve();
+      dfd.reject(err);
+      return;
     }
+    archive.file(zipPath, data);
+    dfd.resolve();
   });
   return dfd.promise;
 }


### PR DESCRIPTION
-Updating zip library from node-native-zip to node-zip since the former has been abandoned. Also, node-zip doesn't have the OS X Archive Utility bug.
-Modifying some relative paths to use __dirname since, on production, the node process is executed from outside the app root. Since relative paths are relative to process.cwd(), this was causing the download to hang.

https://jira.corp.tune.com/browse/HF-1235
